### PR TITLE
Chore/route improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,15 @@ API REST para gerenciamento de tarefas desenvolvida com NestJS e TypeScript.
 
 ## 📋 Endpoints
 
-| Método | Rota          | Descrição                     |
-|--------|---------------|-------------------------------|
-| `GET`  | `/api/tasks`  | Lista todas as tarefas        |
-| `POST` | `/api/tasks`  | Cria uma nova tarefa          |
-| `PATCH`| `/api/tasks/:id/done` | Marca tarefa como concluída |
-| `GET`  | `/health`     | Verifica o status da aplicação |
+## 📋 Endpoints
+
+| Método  | Rota                | Descrição                     |
+|---------|---------------------|-------------------------------|
+| `GET`   | `/api/tasks`        | Lista todas as tarefas        |
+| `POST`  | `/api/tasks`        | Cria uma nova tarefa          |
+| `PATCH` | `/api/tasks/:id/done` | Marca tarefa como concluída   |
+| `DELETE`| `/api/tasks/:id`    | Deleta uma tarefa pelo ID      |
+| `GET`   | `/health`           | Verifica o status da aplicação |
 
 ## 🛠️ Como executar
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ npm install
 npm run start:dev
 ```
 
+> **Nota:** Por padrão, a aplicação será executada na porta `3000`. Caso essa porta não esteja disponível, será utilizada a próxima porta livre. Você pode configurar uma porta específica definindo a variável de ambiente `PORT` antes de iniciar a aplicação:
+
+```bash
+# Exemplo: executar na porta 4000
+set PORT=4000 && npm run start:dev
+```
+
 ### Docker
 
 ```bash
@@ -49,9 +56,8 @@ docker-compose up -d
 
 ### URLs de acesso
 
-- **API**: http://localhost:3001
-- **Documentação**: http://localhost:3001 (Swagger UI)
-- **Endpoints**: http://localhost:3001/api/tasks
+- **API**: http://localhost:3000 (ou a porta configurada)
+- **Documentação**: http://localhost:3000 (Swagger UI)
 
 ## 🧪 Testes
 
@@ -70,15 +76,15 @@ npm run test:cov
 
 ```bash
 # Criar tarefa
-curl -X POST http://localhost:3001/api/tasks \
+curl -X POST http://localhost:3000/api/tasks \
   -H "Content-Type: application/json" \
   -d '{"title": "Estudar NestJS", "description": "Aprender sobre DTOs"}'
 
 # Listar tarefas
-curl http://localhost:3001/api/tasks
+curl http://localhost:3000/api/tasks
 
 # Marcar como concluída
-curl -X PATCH http://localhost:3001/api/tasks/1/done
+curl -X PATCH http://localhost:3000/api/tasks/1/done
 ```
 
 ## ⚠️ Observações
@@ -86,3 +92,4 @@ curl -X PATCH http://localhost:3001/api/tasks/1/done
 - Dados armazenados em memória (perdidos ao reiniciar)
 - Validação automática nos dados de entrada
 - Documentação interativa
+- Porta padrão: `3000` (configurável via variável de ambiente `PORT`)

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ API REST para gerenciamento de tarefas desenvolvida com NestJS e TypeScript.
 
 ## 📋 Endpoints
 
-| Método | Rota | Descrição |
-|--------|------|-----------|
-| `GET` | `/api/tasks` | Lista todas as tarefas |
-| `POST` | `/api/tasks` | Cria uma nova tarefa |
-| `PATCH` | `/api/tasks/:id/done` | Marca tarefa como concluída |
+| Método | Rota          | Descrição                     |
+|--------|---------------|-------------------------------|
+| `GET`  | `/api/tasks`  | Lista todas as tarefas        |
+| `POST` | `/api/tasks`  | Cria uma nova tarefa          |
+| `PATCH`| `/api/tasks/:id/done` | Marca tarefa como concluída |
+| `GET`  | `/health`     | Verifica o status da aplicação |
 
 ## 🛠️ Como executar
 

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   Post,
   Patch,
+  Delete,
   Param,
   Body,
   ValidationPipe,
@@ -67,8 +68,8 @@ export class TasksController {
     return this.tasksService.markAsDone(id);
   }
 
-  @Get(':id')
-  @ApiOperation({ summary: 'Get task by ID' })
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a task by ID' })
   @ApiParam({
     name: 'id',
     type: 'string',
@@ -76,9 +77,12 @@ export class TasksController {
     example: '550e8400-e29b-41d4-a716-446655440000',
     required: true,
   })
-  @ApiResponse({ status: HttpStatus.OK, description: 'Return the task.' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'The task has been successfully deleted.',
+  })
   @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Task not found.' })
-  findById(@Param('id') id: string): Task {
-    return this.tasksService.findById(id);
+  delete(@Param('id') id: string): void {
+    this.tasksService.delete(id);
   }
 }

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   ValidationPipe,
   HttpStatus,
+  HttpException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { TasksService } from './tasks.service';
@@ -21,8 +22,16 @@ export class TasksController {
   @Get()
   @ApiOperation({ summary: 'Get all tasks' })
   @ApiResponse({ status: HttpStatus.OK, description: 'Return all tasks.' })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'No tasks found.',
+  })
   findAll(): Task[] {
-    return this.tasksService.findAll();
+    const tasks = this.tasksService.findAll();
+    if (tasks.length === 0) {
+      throw new HttpException('No tasks found', HttpStatus.NO_CONTENT);
+    }
+    return tasks;
   }
 
   @Post()

--- a/src/tasks/tasks.service.spec.ts
+++ b/src/tasks/tasks.service.spec.ts
@@ -65,23 +65,4 @@ describe('TasksService', () => {
       service.markAsDone('550e8400-e29b-41d4-a716-446655440000'),
     ).toThrow(NotFoundException);
   });
-
-  it('should find task by id', () => {
-    const createTaskDto: CreateTaskDto = {
-      title: 'Test Task',
-    };
-
-    const task = service.create(createTaskDto);
-    const foundTask = service.findById(task.id);
-
-    expect(foundTask).toBeDefined();
-    expect(foundTask.id).toBe(task.id);
-    expect(foundTask.title).toBe('Test Task');
-  });
-
-  it('should throw NotFoundException when finding non-existent task', () => {
-    expect(() =>
-      service.findById('550e8400-e29b-41d4-a716-446655440000'),
-    ).toThrow(NotFoundException);
-  });
 });

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -10,7 +10,7 @@ export class TasksService {
   private readonly tasks: Map<string, Task> = new Map<string, Task>();
 
   findAll(): Task[] {
-    return Array.from(this.tasks.values());
+    return Array.from(this.tasks.values()).reverse();
   }
 
   create(createTaskDto: CreateTaskDto): Task {

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -34,12 +34,11 @@ export class TasksService {
     return task;
   }
 
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
-  findById(id: string): Task {
+  delete(id: string): void {
     const task = this.tasks.get(id);
     if (!task) {
       throw new NotFoundException('Task not found');
     }
-    return task;
+    this.tasks.delete(id);
   }
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -134,6 +134,45 @@ describe('AppController (e2e)', () => {
     });
   });
 
+  describe('/api/tasks/:id (DELETE)', () => {
+    it('should delete a task by ID', async () => {
+      // Criar uma task
+      const createTaskDto = {
+        title: 'Task to delete',
+        description: 'This task will be deleted',
+      };
+
+      const createResponse = await request(app.getHttpServer())
+        .post('/api/tasks')
+        .send(createTaskDto)
+        .expect(201);
+
+      const taskId = createResponse.body.id;
+
+      // Deletar a task
+      await request(app.getHttpServer())
+        .delete(`/api/tasks/${taskId}`)
+        .expect(200);
+
+      // Verificar se a task foi removida
+      await request(app.getHttpServer())
+        .get('/api/tasks')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveLength(0);
+        });
+    });
+
+    it('should return 404 for non-existent task', () => {
+      return request(app.getHttpServer())
+        .delete('/api/tasks/550e8400-e29b-41d4-a716-446655440000')
+        .expect(404)
+        .expect((res) => {
+          expect(res.body.message).toBe('Task not found');
+        });
+    });
+  });
+
   describe('Integration test - Full workflow', () => {
     it('should create, list, and complete a task', async () => {
       // 1. Verificar lista vazia


### PR DESCRIPTION
This pull request adds a new endpoint for deleting tasks by ID, updates related documentation and tests, and improves some aspects of the API's behavior and usability. The main changes are grouped below:

**API Endpoint Changes:**

* Added a new `DELETE /api/tasks/:id` endpoint to allow deletion of tasks by ID, including controller and service logic (`TasksController`, `TasksService`). [[1]](diffhunk://#diff-9aadf1cdc7863f784669039c0f6f0119111cf84b9ff294da6e9a198874620b9cL61-R86) [[2]](diffhunk://#diff-e1b01621005b77eebcd90f83768fea19537f624f41ab76f85641e503dcae1228L37-R42)
* Updated the `findAll` endpoint to return a `204 No Content` error when there are no tasks, and to return tasks in reverse order (most recent first). [[1]](diffhunk://#diff-9aadf1cdc7863f784669039c0f6f0119111cf84b9ff294da6e9a198874620b9cR26-R35) [[2]](diffhunk://#diff-e1b01621005b77eebcd90f83768fea19537f624f41ab76f85641e503dcae1228L13-R13)

**Documentation Updates:**

* Updated the `README.md` to document the new delete endpoint, clarify default port usage, and correct example URLs to use port `3000` instead of `3001`. Also added instructions for configuring the port via environment variable. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25-R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47-R53) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R64) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R99)

**Testing Improvements:**

* Added new e2e tests for the delete endpoint, including tests for successful deletion and error handling when deleting a non-existent task.
* Removed obsolete unit tests for the `findById` method, which is no longer exposed in the controller.

These changes improve the API's functionality and documentation, making it easier to manage tasks and understand how to use the service.